### PR TITLE
Fix truncated tweets problem

### DIFF
--- a/timeline_dev.py
+++ b/timeline_dev.py
@@ -41,7 +41,7 @@ def timeline(filename, handle, replies, api):
     with open(filename, 'a') as outfile:
         timeline = tweepy.Cursor(api.user_timeline, 
                                  screen_name=handle, 
-                                 count=200).items()
+                                 count=200,tweet_mode='extended').items()
         collecting = True
 
         while collecting:


### PR DESCRIPTION
All API results now have "full_text" field instead of "text" field. The logs contain errors for all objects, but it doesn't break the script.